### PR TITLE
특정 날짜, 요일의 루틴 추가, 리스트 조회 api 생성

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Jobs\AssignRoutineScheduleJob;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -15,7 +16,8 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        // 루틴을 해당일의 일정으로 등록
+        $schedule->job(new AssignRoutineScheduleJob())->dailyAt('00:00');
     }
 
     /**

--- a/app/Http/Controllers/RoutineController.php
+++ b/app/Http/Controllers/RoutineController.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Tag;
+use App\Models\Routine;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+
+class RoutineController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        // 사용자 정보
+        $user = $request->get('user');
+
+        $routines = Routine::where('user_id', $user->id)->get();
+
+        return response()->json([
+            'routines' => $routines
+        ]);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        $this->validate($request, [
+            'contents' => 'required|string',
+            'tag_id' => 'integer|min:0',
+            'start_date' => 'required|date|date_format:Y-m-d|after:now',
+            'end_date' => 'nullable|date|date_format:Y-m-d|after_or_equal:start_date',
+            'type' => 'required|string|in:month,week',
+            'schedules' => 'required|array',
+            'schedules.dates' => 'required_if:schedules.days_of_week,null|array',
+            'schedules.dates.*' => 'nullable|integer|min:1|max:31',
+            'schedules.days_of_week' => 'required_if:schedules.dates,null|array',
+            'schedules.days_of_week.*' => 'nullable|string|in:mon,tue,wed,thu,fri,sat,sun',
+        ], [
+            '*' => __('validations.format'),
+        ]);
+
+        // 사용자 정보
+        $user = $request->get('user');
+
+        // 일정 내용
+        $contents = $request->input('contents');
+        // 태그 아이디
+        $tag_id = $request->input('tag_id');
+        // 날짜
+        $startDate = $request->input('start_date');
+        $endDate = $request->input('end_date');
+        $type = $request->input('type');
+        $schedules = $request->input('schedules');
+
+        $tag = Tag::where('user_id', $user->id)->find($tag_id);
+
+        if ($type === 'month' && (empty($schedules['dates']) || $schedules['dates'] === null)) {
+            abort(403, __(111));
+        }
+        if ($type === 'week' && (empty($schedules['days_of_week']) || $schedules['days_of_week'] === null)) {
+            abort(403, __(222));
+        }
+
+        $routine = new Routine();
+        $routine->user_id = $user->id;
+        $routine->contents = $contents;
+        $routine->start_date = $startDate;
+        $routine->end_date = $endDate;
+        $routine->type = $type;
+        $routine->schedules = [
+            'dates' => $schedules['dates'] !== null && $type === 'month' ? $schedules['dates'] : [],
+            'days_of_week' => $schedules['days_of_week'] !== null && $type === 'week' ? $schedules['days_of_week'] : [],
+        ];
+        $routine->tag_id = $tag !== null ? $tag->id : null;
+        $routine->save();
+
+        return response()->json([
+            'result' => 'success'
+        ], 201);
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Models\Tag;
-use App\Models\TagToTask;
 use App\Models\Task;
 use Carbon\Carbon;
 use Illuminate\Http\Request;

--- a/app/Jobs/AssignRoutineScheduleJob.php
+++ b/app/Jobs/AssignRoutineScheduleJob.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Routine;
+use App\Models\Task;
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class AssignRoutineScheduleJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $now = Carbon::now()->startOfDay();
+
+        $routines = Routine::with('tag')
+                            ->whereDate('start_date', '<=', $now->toDateString())
+                            ->where(function ($query) use ($now) {
+                                $query
+                                    ->whereDate('end_date', '>=', $now->toDateString())
+                                    ->orWhere('end_date', null);
+                            })
+                            ->where(function ($query) use ($now) {
+                                $query
+                                    ->where('type', 'month')
+                                    ->whereJsonContains('schedules->dates', $now->day);
+                            })
+                            ->orWhere(function ($query) use ($now) {
+                                $query
+                                    ->where('type', 'week')
+                                    ->whereJsonContains('schedules->days_of_week', strtolower($now->shortEnglishDayOfWeek));
+                            })
+                            ->get();
+
+        $routines->each(function ($routine) use ($now) {
+            $task = new Task();
+            $task->user_id = $routine->user_id;
+            $task->contents = $routine->contents;
+            $task->date = $now->toDateString();
+            $task->tag_id = $routine->tag !== null ? $routine->tag_id : null;
+            $task->save();
+        });
+    }
+}

--- a/app/Models/Routine.php
+++ b/app/Models/Routine.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Routine extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    protected $fillable = [
+        'contents',
+        'user_id'
+    ];
+
+    protected $casts = [
+        'schedules' => 'array',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function tag()
+    {
+        return $this->belongsTo(Tag::class);
+    }
+}

--- a/config/queue.php
+++ b/config/queue.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('QUEUE_CONNECTION', 'sync'),
+    'default' => env('QUEUE_CONNECTION', 'redis'),
 
     /*
     |--------------------------------------------------------------------------

--- a/database/migrations/2022_12_07_114040_create_routines_table.php
+++ b/database/migrations/2022_12_07_114040_create_routines_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('routines', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('contents', 500)->default('')->comment('일정');
+            $table->foreignId('user_id')->comment('사용자번호')->constrained('users')->cascadeOnUpdate()->cascadeOnDelete();
+            $table->enum('type', ['month', 'week'])->default('week')->comment('반복 유형(달 단위의 날짜 기반, 주 단위의 요일 기반)');
+            $table->json('schedules')->default('[{"dates":[],"days_of_week":[]}]')->comment('반복 일정');
+            $table->date('start_date')->nullable()->comment('루틴 시작일');
+            $table->date('end_date')->nullable()->comment('루틴 종료일');
+            $table->foreignId('tag_id')->nullable()->comment('태그번호')->constrained('tags')->cascadeOnUpdate();
+
+            $table->timestampsTz();
+            $table->softDeletesTz();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('routines');
+    }
+};

--- a/lang/ko/aborts.php
+++ b/lang/ko/aborts.php
@@ -12,4 +12,6 @@ return [
     'do_not_exist_task' => '존재하지 않는 일정입니다.',
     'do_not_upsate_same_password' => '현재 비밀번호와 같은 비밀번호로는 변경할 수 없습니다.',
     'do_not_exist_tag' => '존재하지 않는 태그입니다.',
+    'enter_dates' => '날짜를 입력해주세요.',
+    'enter_days_of_week' => '요일을 입력해주세요.',
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\RegisterController;
+use App\Http\Controllers\RoutineController;
 use App\Http\Controllers\TagController;
 use App\Http\Controllers\TaskController;
 use App\Http\Controllers\UserController;
@@ -82,6 +83,22 @@ Route::group(
                 Route::get('/{tag_id}', [TagController::class, 'show'])->where('tag_id', '[0-9]+');
                 // 태그 삭제
                 Route::delete('/{tag_id}', [TagController::class, 'destroy'])->where('tag_id', '[0-9]+');
+            });
+
+            /**
+             * 반복일정(루틴) 관련
+             */
+            Route::group(['prefix' => 'routines'], function () {
+                // 루틴 추가
+                Route::post('/', [RoutineController::class, 'store']);
+                // 루틴 수정
+                Route::put('/{routine_id}', [RoutineController::class, 'update'])->where('routine_id', '[0-9]+');
+                // 루틴 리스트
+                Route::get('/', [RoutineController::class, 'index']);
+                // 루틴 조회
+                Route::get('/{routine_id}', [RoutineController::class, 'show'])->where('routine_id', '[0-9]+');
+                // 루틴 삭제
+                Route::delete('/{routine_id}', [RoutineController::class, 'destroy'])->where('routine_id', '[0-9]+');
             });
         });
     }


### PR DESCRIPTION
- 특정 날짜, 특정 요일의 루틴 추가, 리스트 조회 api 생성
  루틴을 생성하는 날짜보다 이후로 시작일 지정가능, 태그, 내용을 일정과 동일하게 입력 가능
  매일 반복하는 루틴은 주 단위의 모든 요일을 선택
- 1일 1회(자정) 루틴을 조회해 task에 추가하는 job 생성(queue로 동작)